### PR TITLE
Update api.py

### DIFF
--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -464,6 +464,7 @@ for method_name, method in inspect.getmembers(PyRRef):
     """
     docstring = getattr(method, "__doc__", None)
     assert docstring is not None, "RRef user-facing methods should all have docstrings."
+    if docstring is None: continue
 
     # Do surgery on pybind11 generated docstrings.
     docstring = docstring.replace("torch.distributed.rpc.PyRRef", "torch.distributed.rpc.RRef")


### PR DESCRIPTION
Missing docstring should not cause an assertion failure, which it does on my machine.